### PR TITLE
Expose stuff

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ mod vcd;
 pub use vcd::parse::parse_vcd;
 pub use vcd::types::{ScopeIdx, SignalIdx, VCD};
 pub use vcd::types::{Metadata, Timescale, Version};
-pub use vcd::signal::{Signal};
+pub use vcd::signal::{Signal, SignalValue};
 
 pub use num::BigUint;

--- a/src/vcd/parse.rs
+++ b/src/vcd/parse.rs
@@ -11,7 +11,7 @@ mod scopes;
 mod events;
 
 
-pub fn parse_vcd(file: File) -> Result<super::types::VCD, String> {
+pub fn parse_vcd(file: impl std::io::Read) -> Result<super::types::VCD, String> {
     let mut word_gen = super::reader::WordReader::new(file);
 
     let header = metadata::parse_metadata(&mut word_gen)?;

--- a/src/vcd/parse.rs
+++ b/src/vcd/parse.rs
@@ -2,7 +2,6 @@
 // This program is distributed under both the GPLV3 license
 // and the YEHOWSHUA license, both of which can be found at
 // the root of the folder containing the sources for this program.
-use std::fs::File;
 
 mod combinator_atoms;
 mod types;

--- a/src/vcd/parse.rs
+++ b/src/vcd/parse.rs
@@ -27,6 +27,7 @@ pub fn parse_vcd(file: File) -> Result<super::types::VCD, String> {
         all_signals: vec![],
         all_scopes: vec![],
         root_scopes: vec![],
+        largest_timestamp: None
     };
 
     scopes::parse_scopes(&mut word_gen, &mut vcd, &mut signal_map)?;

--- a/src/vcd/parse/combinator_atoms.rs
+++ b/src/vcd/parse/combinator_atoms.rs
@@ -69,7 +69,10 @@ pub(super) fn tag<'a>(word: &'a str, pattern: &'a str) -> ParseResult<'a> {
     };
 }
 
-pub(super) fn ident(word_reader: &mut WordReader, keyword: &str) -> Result<(), String> {
+pub(super) fn ident<R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
+    keyword: &str,
+) -> Result<(), String> {
     // let keyword = "module";
     let (word, cursor) = next_word!(word_reader)?;
 

--- a/src/vcd/parse/events.rs
+++ b/src/vcd/parse/events.rs
@@ -12,8 +12,8 @@ use super::super::reader::{WordReader, Cursor, Line, Word, next_word};
 use super::super::types::{SignalIdx, VCD};
 
 
-pub(super) fn parse_events<'a>(
-    word_reader: &mut WordReader,
+pub(super) fn parse_events<'a, R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
     vcd: &'a mut VCD,
     signal_map: &mut HashMap<String, SignalIdx>,
 ) -> Result<(), String> {

--- a/src/vcd/parse/metadata.rs
+++ b/src/vcd/parse/metadata.rs
@@ -145,7 +145,7 @@ pub(super) fn parse_date(
     ))
 }
 
-pub(super) fn parse_version(word_reader: &mut WordReader) -> Result<Version, String> {
+pub(super) fn parse_version<R: std::io::Read>(word_reader: &mut WordReader<R>) -> Result<Version, String> {
     let mut version = String::new();
 
     loop {
@@ -162,8 +162,8 @@ pub(super) fn parse_version(word_reader: &mut WordReader) -> Result<Version, Str
     }
 }
 
-pub(super) fn parse_timescale(
-    word_reader: &mut WordReader,
+pub(super) fn parse_timescale<R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
 ) -> Result<(Option<u32>, Timescale), String> {
     // we might see `1ps $end` or `1 ps $end`
     // first get timescale
@@ -220,7 +220,7 @@ pub(super) fn parse_timescale(
     return Ok(timescale);
 }
 
-pub(super) fn parse_metadata(word_reader: &mut WordReader) -> Result<Metadata, String> {
+pub(super) fn parse_metadata<R: std::io::Read>(word_reader: &mut WordReader<R>) -> Result<Metadata, String> {
     let mut metadata = Metadata {
         date: None,
         version: None,

--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -97,7 +97,11 @@ pub(super) fn parse_var<'a>(
         let (word, _) = next_word!(word_reader)?;
         match word {
             "$end" => break,
-            _ => full_signal_name.push(word.to_string()),
+            other => {
+                if !other.starts_with("[") {
+                    full_signal_name.push(word.to_string())
+                }
+            }
         }
     }
     let full_signal_name = full_signal_name.join(" ");

--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -15,8 +15,8 @@ use super::super::signal::{SigType, SignalEnum};
 use super::combinator_atoms::{tag, ident};
 use super::types::{ParseResult};
 
-pub(super) fn parse_var<'a>(
-    word_reader: &mut WordReader,
+pub(super) fn parse_var<'a, R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
     parent_scope_idx: ScopeIdx,
     vcd: &'a mut VCD,
     signal_map: &mut HashMap<String, SignalIdx>,
@@ -157,8 +157,8 @@ pub(super) fn parse_var<'a>(
 
 /// Sometimes, variables can be listed outside of scopes.
 /// We call these orphaned vars.
-fn parse_orphaned_vars<'a>(
-    word_reader: &mut WordReader,
+fn parse_orphaned_vars<'a, R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
     vcd: &'a mut VCD,
     signal_map: &mut HashMap<String, SignalIdx>,
 ) -> Result<(), String> {
@@ -221,8 +221,8 @@ fn parse_orphaned_vars<'a>(
     Ok(())
 }
 
-fn parse_scopes_inner<'a>(
-    word_reader: &mut WordReader,
+fn parse_scopes_inner<'a, R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
     parent_scope_idx: Option<ScopeIdx>,
     vcd: &'a mut VCD,
     signal_map: &mut HashMap<String, SignalIdx>,
@@ -328,8 +328,8 @@ fn parse_scopes_inner<'a>(
     Ok(())
 }
 
-pub(super) fn parse_scopes<'a>(
-    word_reader: &mut WordReader,
+pub(super) fn parse_scopes<'a, R: std::io::Read>(
+    word_reader: &mut WordReader<R>,
     vcd: &'a mut VCD,
     signal_map: &mut HashMap<String, SignalIdx>,
 ) -> Result<(), String> {

--- a/src/vcd/reader.rs
+++ b/src/vcd/reader.rs
@@ -3,7 +3,6 @@
 // and the YEHOWSHUA license, both of which can be found at
 // the root of the folder containing the sources for this program.
 use std::collections::VecDeque;
-use std::fs::File;
 use std::io;
 use std::io::BufRead;
 use std::slice;
@@ -16,8 +15,8 @@ pub(super) struct Word(pub(super) usize);
 #[derive(Debug, Clone)]
 pub(super) struct Cursor(pub(super) Line, pub(super) Word);
 
-pub(super) struct WordReader {
-    reader: io::BufReader<File>,
+pub(super) struct WordReader<R: io::Read> {
+    reader: io::BufReader<R>,
     eof: bool,
     buffers: Vec<String>,
     curr_line: usize,
@@ -25,11 +24,11 @@ pub(super) struct WordReader {
     curr_slice: Option<(*const u8, usize, Cursor)>,
 }
 
-impl WordReader {
-    pub(super) fn new(file: File) -> WordReader {
+impl<R: std::io::Read> WordReader<R> {
+    pub(super) fn new(file: R) -> WordReader<R> {
         let reader = io::BufReader::new(file);
         WordReader {
-            reader: reader,
+            reader,
             eof: false,
             buffers: vec![],
             curr_line: 0,

--- a/src/vcd/signal.rs
+++ b/src/vcd/signal.rs
@@ -63,7 +63,7 @@ impl<'a> Signal<'a> {
         &self,
         desired_time: &BigUint,
         vcd: &types::VCD,
-    ) -> Result<SignalValue, SignalErrors> {
+    ) -> Result<(TimeStamp, SignalValue), SignalErrors> {
         let Signal(signal_enum) = &self;
         let num_val = signal_enum
             .query_num_val_on_tmln(
@@ -84,14 +84,14 @@ impl<'a> Signal<'a> {
         match (num_val, str_val) {
             (Ok((num_val, num_time)), Ok((str_val, str_time))) => {
                 if num_time > str_time {
-                    Ok(SignalValue::BigUint(num_val))
+                    Ok((num_time, SignalValue::BigUint(num_val)))
                 }
                 else {
-                    Ok(SignalValue::String(str_val))
+                    Ok((str_time, SignalValue::String(str_val)))
                 }
             }
-            (Ok((num_val, _)), Err(_)) => Ok(SignalValue::BigUint(num_val)),
-            (Err(_), Ok((str_val, _))) => Ok(SignalValue::String(str_val)),
+            (Ok((num_val, time)), Err(_)) => Ok((time, SignalValue::BigUint(num_val))),
+            (Err(_), Ok((str_val, time))) => Ok((time, SignalValue::String(str_val))),
             (Err(e), _e) => Err(e)
         }
     }

--- a/src/vcd/signal.rs
+++ b/src/vcd/signal.rs
@@ -2,9 +2,9 @@
 // This program is distributed under both the GPLV3 license
 // and the YEHOWSHUA license, both of which can be found at
 // the root of the folder containing the sources for this program.
-use super::types::{ScopeIdx, SignalIdx};
+use super::types::SignalIdx;
 use super::types;
-use num::{BigUint};
+use num::BigUint;
 
 // Index to the least significant byte of a timestamp
 // value on the timeline
@@ -35,6 +35,13 @@ impl<'a> Signal<'a> {
     pub fn name(&self) -> String {
         let Signal(signal_enum) = &self;
         signal_enum.name()
+    }
+
+    pub fn path(&self) -> &[String] {
+        match self.0 {
+            SignalEnum::Data {path, ..} => path,
+            SignalEnum::Alias { path, .. } => path,
+        }
     }
 
     pub fn num_bits(&self) -> Option<u16> {
@@ -101,6 +108,7 @@ impl<'a> Signal<'a> {
 pub(super) enum SignalEnum {
     Data {
         name: String,
+        path: Vec<String>,
         sig_type: SigType,
         /// I've seen a 0 bit signal parameter in a xilinx
         /// simulation before that gets assigned 1 bit values.
@@ -136,10 +144,10 @@ pub(super) enum SignalEnum {
         byte_len_of_num_tmstmp_vals_on_tmln: Vec<u8>,
         byte_len_of_string_tmstmp_vals_on_tmln: Vec<u8>,
         lsb_indxs_of_string_tmstmp_vals_on_tmln: Vec<LsbIdxOfTmstmpValOnTmln>,
-        scope_parent: ScopeIdx,
     },
     Alias {
         name: String,
+        path: Vec<String>,
         signal_alias: SignalIdx,
     },
 }
@@ -305,7 +313,7 @@ impl SignalEnum {
         match self {
             SignalEnum::Data {num_bits, ..} => num_bits.clone(),
             // TODO: Follow aliases?
-            SignalEnum::Alias { name, signal_alias } => None,
+            SignalEnum::Alias { .. } => None,
         }
     }
 }
@@ -329,6 +337,7 @@ impl SignalEnum {
             Self::Alias {
                 name: _,
                 signal_alias,
+                path: _
             } => {
                 let SignalIdx(idx) = signal_alias;
                 *idx
@@ -443,6 +452,7 @@ impl SignalEnum {
             }
             Self::Alias {
                 name: _,
+                path: _,
                 signal_alias,
             } => {
                 let SignalIdx(idx) = signal_alias;

--- a/src/vcd/types.rs
+++ b/src/vcd/types.rs
@@ -5,6 +5,7 @@
 // and the YEHOWSHUA license, both of which can be found at
 // the root of the folder containing the sources for this program.
 use chrono::prelude::{DateTime, Utc};
+use num::BigUint;
 use super::signal::{Signal, SignalEnum};
 
 #[derive(Debug)]
@@ -63,6 +64,7 @@ pub struct VCD {
     pub(super) all_signals: Vec<SignalEnum>,
     pub(super) all_scopes: Vec<Scope>,
     pub(super) root_scopes: Vec<ScopeIdx>,
+    pub(super) largest_timestamp: Option<BigUint>
 }
 
 impl VCD {
@@ -120,5 +122,9 @@ impl VCD {
                 line!()
             )),
         }
+    }
+
+    pub fn max_timestamp(&self) -> &Option<BigUint> {
+        &self.largest_timestamp
     }
 }

--- a/src/vcd/types.rs
+++ b/src/vcd/types.rs
@@ -40,7 +40,6 @@ pub struct SignalIdx(pub usize);
 pub(super) struct Scope {
     pub(super) name: String,
 
-    pub(super) parent_idx: Option<ScopeIdx>,
     pub(super) self_idx: ScopeIdx,
 
     pub(super) child_signals: Vec<SignalIdx>,

--- a/src/vcd/types.rs
+++ b/src/vcd/types.rs
@@ -29,10 +29,10 @@ pub struct Metadata {
 }
 
 // We do a lot of arena allocation in this codebase.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ScopeIdx(pub usize);
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SignalIdx(pub usize);
 
 #[derive(Debug)]


### PR DESCRIPTION
These are the changes I need for my experimental vcd viewer so far:

- Deriving extra traits for the indices is needed for me to efficiently keep track of the last time a signal was changed
- Last timestamp is needed to figure out how wide to make the default view
- `byte_len_of_string_tmstmp_vals_on_tmln.push(curr_tmstmp_len_u8);` fixes a panic when indexing into string values
- SignalValue and associated functions properly expose the current value of the signal