### PR TITLE
Replace deprecated method

### DIFF
--- a/src/vcd/parse/metadata.rs
+++ b/src/vcd/parse/metadata.rs
@@ -2,7 +2,7 @@
 // This program is distributed under both the GPLV3 license
 // and the YEHOWSHUA license, both of which can be found at
 // the root of the folder containing the sources for this program.
-use chrono::prelude::{DateTime, Utc, TimeZone};
+use chrono::prelude::{DateTime, Utc};
 use itertools::Itertools;
 
 use super::super::reader::{Cursor, WordReader, next_word};
@@ -133,9 +133,9 @@ pub(super) fn parse_date(
     // unfortunately, the minutes, seconds, and hour could occur in an
     // unexpected order
     let full_date = format!("{day} {month} {date} {hh}:{mm}:{ss} {year}");
-    let full_date = Utc.datetime_from_str(full_date.as_str(), "%a %b %e %T %Y");
+    let full_date = DateTime::parse_from_str(full_date.as_str(), "%a %b %e %T %Y");
     if full_date.is_ok() {
-        return Ok(full_date.unwrap());
+        return Ok(full_date.unwrap().into());
     }
 
     Err(format!(


### PR DESCRIPTION
While running surfer, the following deprecation warning, originating from FastWaveBackend, is emitted:

```
warning: use of deprecated method `chrono::TimeZone::datetime_from_str`: use `DateTime::parse_from_str` instead
   --> FastWaveBackend/src/vcd/parse/metadata.rs:136:25
    |
136 |     let full_date = Utc.datetime_from_str(full_date.as_str(), "%a %b %e %T %Y");
    |                         ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `fastwave_backend` (lib) generated 1 warning
   Compiling surfer v0.1.0 (/local/data1/surfer)
    Finished dev [unoptimized + debuginfo] target(s) in 14.91s
     Running `target/debug/surfer`
```