### PR TITLE
Keep index as part of signal name

### DIFF
--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -98,11 +98,7 @@ pub(super) fn parse_var<'a, R: std::io::Read>(
         let (word, _) = next_word!(word_reader)?;
         match word {
             "$end" => break,
-            other => {
-                if !other.starts_with("[") {
-                    full_signal_name.push(word.to_string())
-                }
-            }
+            _ => full_signal_name.push(word.to_string())
         }
     }
     let full_signal_name = full_signal_name.join(" ");


### PR DESCRIPTION
Related to #9 

I realize that the current behavior is a design choice, but probably it is better to leave it to the viewer to decide if this should be included or not.