### PR TITLE
Separate name from width

### DIFF
--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -126,10 +126,12 @@ pub(super) fn parse_var<R: std::io::Read>(
     // $var parameter 3 a IDLE $end
     //                    ^^^^ - full_signal_name(can extend until $end)
     let mut full_signal_name = Vec::<String>::new();
+    let mut size = None;
     loop {
         let (word, _) = next_word!(word_reader)?;
         match word {
             "$end" => break,
+            other if other.starts_with('[') => size = Some(other.to_string()),
             _ => full_signal_name.push(word.to_string()),
         }
     }
@@ -170,6 +172,7 @@ pub(super) fn parse_var<R: std::io::Read>(
                     .chain([full_signal_name])
                     .collect::<Vec<String>>(),
                 signal_type: var_type,
+                index: size,
                 signal_error: None,
                 num_bits,
                 num_bytes,

--- a/src/vcd/signal.rs
+++ b/src/vcd/signal.rs
@@ -48,6 +48,11 @@ impl<'a> Signal<'a> {
         signal_enum.name()
     }
 
+    pub fn name_with_size(&self) -> String {
+        let Signal(signal_enum) = &self;
+        signal_enum.name_with_index()
+    }
+
     pub fn path(&self) -> &[String] {
         match self.0 {
             SignalEnum::Data { path, .. } => path,
@@ -135,6 +140,9 @@ pub(super) enum SignalEnum {
         name: String,
         path: Vec<String>,
         signal_type: SignalType,
+        /// The optional [start:end] part of the signal name that is sometimes
+        /// added to signals
+        index: Option<String>,
         /// I've seen a 0 bit signal parameter in a xilinx
         /// simulation before that gets assigned 1 bit values.
         /// I consider this to be bad behavior. We capture such
@@ -217,6 +225,20 @@ impl SignalEnum {
             SignalEnum::Alias { .. } => None,
         }
         .clone()
+    }
+
+    pub fn name_with_index(&self) -> String {
+        match self {
+            SignalEnum::Data {
+                name, index: None, ..
+            } => format!("{name}"),
+            SignalEnum::Data {
+                name,
+                index: Some(size),
+                ..
+            } => format!("{name} {size}"),
+            SignalEnum::Alias { name, .. } => name.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
It is useful to have both around, but for things that look for particular signals by name, having the width always included in the name is problematic. For example in https://gitlab.com/surfer-project/surfer/-/issues/59

CC: @oscargus since you made the original change