### PR TITLE
Add support for fork scopes

### DIFF
--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -238,7 +238,7 @@ fn parse_scopes_inner<R: std::io::Read>(
     //        ^^^^^^ - module keyword
     let (keyword, cursor) = next_word!(word_reader)?;
 
-    let expected = ["module", "begin", "task", "function"];
+    let expected = ["module", "begin", "task", "function", "fork"];
     if expected.contains(&keyword) {
         Ok(())
     } else {


### PR DESCRIPTION
Based on 18.2.3.4 $scope of the Verilog standard, there is a fifth scope type: `fork`, which at least ModelSim outputs.