### PR TITLE
Revert "Add support for real values"

### DIFF
--- a/src/vcd/parse/events.rs
+++ b/src/vcd/parse/events.rs
@@ -537,51 +537,6 @@ pub(super) fn parse_events<R: std::io::Read>(
                     }
                 }?;
             }
-            "r" => {
-                let val = word[1..].to_string();
-                let (hash, cursor) = next_word!(word_reader)?;
-                // lokup signal idx
-                let signal_idx = signal_map.get(hash).ok_or(()).map_err(|_| {
-                    format!(
-                        "Error near {}:{}. Failed to lookup signal {hash} at {cursor:?}",
-                        file!(),
-                        line!()
-                    )
-                })?;
-
-                let signal = vcd.dealiasing_signal_idx_to_signal_lookup_mut(signal_idx)?;
-
-                match signal {
-                    SignalEnum::Data {
-                        ref mut signal_error,
-                        real_vals,
-                        byte_len_of_real_tmstmp_vals_on_tmln,
-                        lsb_indxs_of_real_tmstmp_vals_on_tmln,
-                        ..
-                    } => {
-                        // if this is a bad signal, go ahead and skip it
-                        if signal_error.is_some() {
-                            continue;
-                        }
-
-                        // record timestamp at which this event occurs
-                        lsb_indxs_of_real_tmstmp_vals_on_tmln
-                            .push(LsbIdxOfTmstmpValOnTmln(curr_tmstmp_lsb_idx));
-                        byte_len_of_real_tmstmp_vals_on_tmln.push(curr_tmstmp_len_u8);
-
-                        // record real value
-                        real_vals.push(val.parse::<f64>().unwrap());
-                        Ok(())
-                    }
-                    SignalEnum::Alias { .. } => {
-                        let (f, l) = (file!(), line!());
-                        let msg = format!(
-                            "Error near {f}:{l}, a signal alias should not point to a signal alias.\n\
-                             This error occurred while parsing vcd file at {cursor:?}");
-                        Err(msg)
-                    }
-                }?;
-            }
             _ => {}
         }
     }

--- a/src/vcd/parse/scopes.rs
+++ b/src/vcd/parse/scopes.rs
@@ -180,9 +180,6 @@ pub(super) fn parse_var<R: std::io::Read>(
                 byte_len_of_num_tmstmp_vals_on_tmln: vec![],
                 byte_len_of_string_tmstmp_vals_on_tmln: vec![],
                 lsb_indxs_of_string_tmstmp_vals_on_tmln: vec![],
-                real_vals: vec![],
-                byte_len_of_real_tmstmp_vals_on_tmln: vec![],
-                lsb_indxs_of_real_tmstmp_vals_on_tmln: vec![],
             };
             (signal, signal_idx)
         }


### PR DESCRIPTION
Reverts ThePerfectComputer/FastWaveBackend#27

We realized that it is annoying to deal with real values in surfer when most signals will just be non-reals. So we're deciding that reals will be stored as strings and downstream tools can parse the reals. If there are other use cases for reals that benefit more from it being preprocessed here, we can revert the revert.