### PR TITLE
Add support for parsing real values (to a String)

### DIFF
--- a/src/vcd/parse/events.rs
+++ b/src/vcd/parse/events.rs
@@ -492,7 +492,8 @@ pub(super) fn parse_events<R: std::io::Read>(
                     }
                 }?;
             }
-            "s" => {
+            // Store real values as a string as well and let the user parse it to an f64
+            "s" | " S" | "r" | "R" => {
                 let val = word[1..].to_string();
                 let (hash, cursor) = next_word!(word_reader)?;
                 // lokup signal idx


### PR DESCRIPTION
Pragmatic alternative to #27 where we now simply store the real value as a String. Much simpler interface and probably one would more often want to print the value than using the f64-version of it.